### PR TITLE
Upgrades Tautulli to v2.1.26

### DIFF
--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=hassioaddons/base:2.3.0
 FROM ${BUILD_FROM}
 
 # Set env
-ENV TAUTULLI_VERSION 'v2.1.25'
+ENV TAUTULLI_VERSION 'v2.1.26'
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
# Proposed Changes

Upgrades Tautulli to v2.1.26.
Changelog: https://github.com/Tautulli/Tautulli/releases/tag/v2.1.26

## Related Issues

n/a

<blockquote><img src="https://avatars3.githubusercontent.com/u/34385001?s=400&v=4" width="48" align="right"><div><img src="https://assets-cdn.github.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/Tautulli/Tautulli">Tautulli/Tautulli</a></strong></div><div>A Python based monitoring and tracking tool for Plex Media Server. - Tautulli/Tautulli</div></blockquote>