### PR TITLE
Updates pycryptodomex to version 3.8.0

### DIFF
--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     pip==19.0.3 \
   && pip install --no-cache-dir -U \
     plexapi==3.1.0 \
-    pycryptodomex==3.7.3 \
+    pycryptodomex==3.8.0 \
     crudini==0.9 \
     PyOpenSSL==19.0.0 \
   \


### PR DESCRIPTION

# Proposed Changes

This PR will update `pycryptodomex` to version `3.8.0`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
