### PR TITLE
Updates gcc to version 6.4.0-r9

### DIFF
--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -18,7 +18,7 @@ COPY requirements.txt /tmp/
 RUN \
   apk add --no-cache --virtual .build-dependencies \
     g++=8.2.0-r2 \
-    gcc=8.2.0-r2 \
+    gcc=6.4.0-r9 \
     make=4.2.1-r2 \
     python2-dev=2.7.15-r3 \
     libffi-dev=3.2.1-r6 \


### PR DESCRIPTION

# Proposed Changes

This PR will update `gcc` to version `6.4.0-r9`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
