### PR TITLE
Updates libffi-dev to version 3.2.1-r4

### DIFF
--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     gcc=8.2.0-r2 \
     make=4.2.1-r2 \
     python2-dev=2.7.15-r3 \
-    libffi-dev=3.2.1-r6 \
+    libffi-dev=3.2.1-r4 \
     libressl-dev=2.7.5-r0 \
   \
   && apk add --no-cache \


### PR DESCRIPTION

# Proposed Changes

This PR will update `libffi-dev` to version `3.2.1-r4`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
