### PR TITLE
Updates py-openssl to version 17.5.0-r0

### DIFF
--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -29,7 +29,7 @@ RUN \
     python2=2.7.15-r3 \
     py2-pip=18.1-r0 \
     wget=1.20.1-r0 \
-    py-openssl=18.0.0-r0 \
+    py-openssl=17.5.0-r0 \
   \
   && pip install --no-cache-dir -U -r /tmp/requirements.txt \
   \


### PR DESCRIPTION

# Proposed Changes

This PR will update `py-openssl` to version `17.5.0-r0`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
