### PR TITLE
Updates pycryptodomex to version 3.8.2

### DIFF
--- a/tautulli/requirements.txt
+++ b/tautulli/requirements.txt
@@ -1,3 +1,3 @@
 plexapi==3.1.0
-pycryptodomex==3.8.1
+pycryptodomex==3.8.2
 crudini==0.9


### PR DESCRIPTION

# Proposed Changes

This PR will update `pycryptodomex` to version `3.8.2`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
