### PR TITLE
Upgrades Tautulli to version v2.1.31

### DIFF
--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=hassioaddons/base:3.1.0
 FROM ${BUILD_FROM}
 
 # Set env
-ENV TAUTULLI_VERSION 'v2.1.29'
+ENV TAUTULLI_VERSION 'v2.1.31'
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION

# Proposed Changes

This PR will update `Tautulli` to version `v2.1.31`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
