### PR TITLE
Fix the Tautulli version not being set up as env variable

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,7 @@
     {
       "fileMatch": ["/Dockerfile$"],
       "matchStrings": [
-        "ARG TAUTULLI_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
+        "ENV TAUTULLI_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "Tautulli/Tautulli"

--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt /tmp/
 
 # Setup base
 ARG BUILD_ARCH=amd64
-ARG TAUTULLI_VERSION="v2.12.2"
+ENV TAUTULLI_VERSION="v2.12.2"
 RUN \
   apt-get update \
   && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
# Proposed Changes

Tautulli uses the version variable at runtime, which was lost when adding Renovate for dependency management. This PR re-introduces it again.
